### PR TITLE
Update scripts for package-based execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ pip install matplotlib
 ## Usage
 Run the application using:
 ```bash
-python main.py
+python -m running_tracker.main
 ```
 
 A window will appear where you can enter the date, distance in km and the time

--- a/build_mac.command
+++ b/build_mac.command
@@ -7,6 +7,6 @@ if ! command -v pyinstaller >/dev/null 2>&1; then
     pip3 install --user pyinstaller
 fi
 
-pyinstaller --windowed --name "RunningTracker" main.py
+pyinstaller --windowed --name "RunningTracker" running_tracker/main.py
 
 echo "App built at dist/RunningTracker.app"

--- a/run.command
+++ b/run.command
@@ -1,4 +1,4 @@
 #!/bin/bash
 # Launch Running Tracker App
 cd "$(dirname "$0")"
-python3 main.py
+python3 -m running_tracker.main

--- a/running_tracker/main.py
+++ b/running_tracker/main.py
@@ -1,0 +1,5 @@
+from running_tracker.gui import RunningTrackerApp
+
+if __name__ == "__main__":
+    app = RunningTrackerApp()
+    app.run()


### PR DESCRIPTION
## Summary
- update run.command to invoke the package entry point
- adjust build_mac.command for new path
- document new launch command in README
- add running_tracker/main.py module

## Testing
- `python3 -m running_tracker.main` *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_b_686d153057ac832d8325eca2bdf1589b