### PR TITLE
Add run management UI

### DIFF
--- a/running_tracker/data_handler.py
+++ b/running_tracker/data_handler.py
@@ -20,3 +20,15 @@ class DataHandler:
         with open(self.filename, newline="") as f:
             reader = csv.DictReader(f)
             return list(reader)
+
+    def remove_run(self, index: int):
+        """Remove a run by its index in the CSV file."""
+        runs = self.get_runs()
+        if index < 0 or index >= len(runs):
+            raise IndexError("Run index out of range")
+        del runs[index]
+        with open(self.filename, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=["date", "distance", "time"])
+            writer.writeheader()
+            for row in runs:
+                writer.writerow(row)


### PR DESCRIPTION
## Summary
- allow removing runs in data handler
- show a table of existing runs with a button to remove selected items
- hook view runs button into main GUI

## Testing
- `python -m running_tracker.main` *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_b_686d179ec7d8832d92762217eee7a46a